### PR TITLE
add oxfam wash beneficiary consent

### DIFF
--- a/code_schemes/beneficiary_consent.json
+++ b/code_schemes/beneficiary_consent.json
@@ -1,0 +1,282 @@
+{
+  "SchemeID": "Scheme-46f4e9f2",
+  "Name": "BENEFICIARY CONSENT",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true,
+      "Shortcut": "q"
+    },
+    {
+      "CodeID": "code-S-461bfcdf",
+      "CodeType": "Meta",
+      "MetaCode": "statement",
+      "DisplayText": "meta: statement",
+      "NumericValue": -100090,
+      "StringValue": "statement",
+      "VisibleInCoda": true,
+      "Shortcut": "s"
+    },
+    {
+      "CodeID": "code-5850d9b7",
+      "CodeType": "Normal",
+      "DisplayText": "about coronavirus",
+      "NumericValue": 1,
+      "StringValue": "about_coronavirus",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-e1c9a440",
+      "CodeType": "Normal",
+      "DisplayText": "how to prevent",
+      "NumericValue": 2,
+      "StringValue": "how_to_prevent",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b68e0826",
+      "CodeType": "Normal",
+      "DisplayText": "follow guidelines/call for right practice",
+      "NumericValue": 3,
+      "StringValue": "follow_guidelines_call_for_right_practice",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-cf9f4e91",
+      "CodeType": "Normal",
+      "DisplayText": "symptoms",
+      "NumericValue": 4,
+      "StringValue": "symptoms",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a747ec94",
+      "CodeType": "Normal",
+      "DisplayText": "treatment/how to treat",
+      "NumericValue": 5,
+      "StringValue": "treatment_how_to_treat",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-36ad098c",
+      "CodeType": "Normal",
+      "DisplayText": "misinfo/rumour/stigma",
+      "NumericValue": 6,
+      "StringValue": "misinfo_rumour_stigma",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-55fbc929",
+      "CodeType": "Normal",
+      "DisplayText": "kenya update",
+      "NumericValue": 7,
+      "StringValue": "kenya_update",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/beneficiary_consent.json
+++ b/code_schemes/beneficiary_consent.json
@@ -1,6 +1,6 @@
 {
   "SchemeID": "Scheme-46f4e9f2",
-  "Name": "BENEFICIARY CONSENT",
+  "Name": "Beneficiary Consent",
   "Version": "0.0.0.1",
   "Codes": [
     {

--- a/code_schemes/ws_correct_dataset.json
+++ b/code_schemes/ws_correct_dataset.json
@@ -81,6 +81,17 @@
       ]
     },
     {
+      "CodeID": "code-5ca601dc",
+      "CodeType": "Normal",
+      "DisplayText": "OXFAM WASH Beneficiary Consent",
+      "StringValue": "oxfam_wash_beneficiary_consent",
+      "NumericValue": 8,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "OXFAM WASH Beneficiary Consent"
+      ]
+    },
+    {
       "CodeID": "code-NC-42f1d983",
       "CodeType": "Control",
       "ControlCode": "NC",

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -13,6 +13,7 @@ class CodeSchemes(object):
     S01E01 = _open_scheme("s01e01.json")
     S01E02 = _open_scheme("s01e02.json")
     S01E03 = _open_scheme("s01e03.json")
+    BENEFICIARY_CONSENT = _open_scheme("beneficiary_consent.json")
 
     KENYA_CONSTITUENCY = _open_scheme("kenya_constituency.json")
     KENYA_COUNTY = _open_scheme("kenya_county.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -72,6 +72,22 @@ def get_rqa_coding_plans(pipeline_name):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("OXFAM-WASH s01e03"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="oxfam_beneficiary_consent_raw",
+                   time_field="sent_on",
+                   run_id_field="oxfam_beneficiary_consent_run_id",
+                   coda_filename="OXFAM_WASH_Beneficiary_Consent.json",
+                   icr_filename="oxfam_beneficiary_consent.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.BENEFICIARY_CONSENT,
+                           coded_field="oxfam_beneficiary_consent_coded",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.BENEFICIARY_CONSENT, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("OXFAM WASH Beneficiary Consent"),
                    raw_field_fold_strategy=FoldStrategies.concatenate)
     ]
 

--- a/configuration/pipeline_config.json
+++ b/configuration/pipeline_config.json
@@ -9,7 +9,9 @@
       "ActivationFlowNames": [
         "oxfam_wash_s01e01_activation",
         "oxfam_wash_s01e02_activation",
-        "oxfam_wash_s01e03_activation"
+        "oxfam_wash_s01e03_activation",
+        "oxfam_wash_s01e01_beneficiaries_sms_ad",
+        "Oxfam_wash_s01e02_beneficiaries_sms_ad"
       ],
       "SurveyFlowNames": [
         "oxfam_wash_s01_demog"
@@ -38,6 +40,14 @@
     {"RapidProKey": "Rqa_S01E03 (Text) - oxfam_wash_s01e03_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
     {"RapidProKey": "Rqa_S01E03 (Run ID) - oxfam_wash_s01e03_activation", "PipelineKey": "rqa_s01e03_run_id"},
     {"RapidProKey": "Rqa_S01E03 (Time) - oxfam_wash_s01e03_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Oxfam_Beneficiary_Consent (Text) - oxfam_wash_s01e01_sms_ad", "PipelineKey": "oxfam_beneficiary_consent_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Oxfam_Beneficiary_Consent (Run ID) - oxfam_wash_s01e01_sms_ad", "PipelineKey": "oxfam_beneficiary_consent_run_id"},
+    {"RapidProKey": "Oxfam_Beneficiary_Consent (Time) - oxfam_wash_s01e01_sms_ad", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Oxfam_Beneficiary_Consent (Text) - Oxfam_wash_s01e02_beneficiaries_sms_ad", "PipelineKey": "oxfam_beneficiary_consent_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Oxfam_Beneficiary_Consent (Run ID) - Oxfam_wash_s01e02_beneficiaries_sms_ad", "PipelineKey": "oxfam_beneficiary_consent_run_id"},
+    {"RapidProKey": "Oxfam_Beneficiary_Consent (Time) - Oxfam_wash_s01e02_beneficiaries_sms_ad", "PipelineKey": "sent_on"},
 
     {"RapidProKey": "Constituency (Text) - oxfam_wash_s01_demog", "PipelineKey": "location_raw"},
     {"RapidProKey": "Constituency (Time) - oxfam_wash_s01_demog", "PipelineKey": "location_time"},

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -23,6 +23,7 @@ DATASETS=(
     "OXFAM_WASH_gender"
     "OXFAM_WASH_location"
     "OXFAM_WASH_disabled"
+    "OXFAM_WASH_Beneficiary_Consent"
 )
 
 cd "$CODA_V2_ROOT/data_tools"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -23,6 +23,7 @@ DATASETS=(
     "OXFAM_WASH_gender"
     "OXFAM_WASH_location"
     "OXFAM_WASH_disabled"
+    "OXFAM_WASH_Beneficiary_Consent"
 )
 
 cd "$CODA_V2_ROOT/data_tools"


### PR DESCRIPTION
We sent out a hybrid consent sms ad to Oxfam beneficiaries. This allows us to manually label non-explicit YES responses so that we can send them this week's question. 